### PR TITLE
Fix iCloud Drive re-optimisation bug

### DIFF
--- a/Clop/Settings.swift
+++ b/Clop/Settings.swift
@@ -86,6 +86,7 @@ extension Defaults.Keys {
     static let specificFolderNameTemplateImage = Key<String>("specificFolderNameTemplateImage", default: DEFAULT_SPECIFIC_FOLDER_NAME_TEMPLATE)
     static let specificFolderNameTemplateVideo = Key<String>("specificFolderNameTemplateVideo", default: DEFAULT_SPECIFIC_FOLDER_NAME_TEMPLATE)
     static let specificFolderNameTemplatePDF = Key<String>("specificFolderNameTemplatePDF", default: DEFAULT_SPECIFIC_FOLDER_NAME_TEMPLATE)
+    static let optimisedFileProtectionMs = Key<Int>("optimisedFileProtectionMs", default: 3000)
 
     static let capVideoFPS = Key<Bool>("capVideoFPS", default: true)
     static let targetVideoFPS = Key<Float>("targetVideoFPS", default: 60)
@@ -258,6 +259,7 @@ let SETTINGS_TO_SYNC: [Defaults._AnyKey] = [
     .optimiseImagePathClipboard,
     .optimiseTIFF,
     .optimiseVideoClipboard,
+    .optimisedFileProtectionMs,
     .pdfDirs,
     .preserveDates,
     .preserveColorMetadata,

--- a/Clop/SettingsView.swift
+++ b/Clop/SettingsView.swift
@@ -1441,6 +1441,7 @@ struct GeneralSettingsView: View {
     @Default(.preserveColorMetadata) var preserveColorMetadata
     @Default(.preserveDates) var preserveDates
     @Default(.syncSettingsCloud) var syncSettingsCloud
+    @Default(.optimisedFileProtectionMs) var optimisedFileProtectionMs
 
     @Default(.workdir) var workdir
     @Default(.workdirCleanupInterval) var workdirCleanupInterval
@@ -1518,6 +1519,16 @@ struct GeneralSettingsView: View {
                 Toggle(isOn: $preserveDates) {
                     Text("Preserve file creation and modification dates").regular(13)
                         + Text("\nThe optimised file will have the same creation and modification dates as the original file").round(11, weight: .regular).foregroundColor(.secondary)
+                }
+
+                Picker(selection: $optimisedFileProtectionMs) {
+                    Text("3 seconds").tag(3000)
+                    Text("10 seconds").tag(10_000)
+                    Text("30 seconds").tag(30_000)
+                    Text("60 seconds").tag(60_000)
+                } label: {
+                    Text("Re-optimisation protection window").regular(13)
+                        + Text("\nIncrease if files on iCloud Drive get optimised twice").round(11, weight: .regular).foregroundColor(.secondary)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Mark original file with xattr** after copying to the `-optimised` path, preventing iCloud sync FSEvents from re-triggering optimisation on the original
- **Add configurable protection window** (`optimisedFileProtectionMs`) defaulting to 3s — users on iCloud Drive can increase to 30s/60s to handle longer sync times
- **Fix memory leak** where `newPath` was inserted into `alreadyOptimisedFiles` but never cleaned up
- **Add UI picker** in General > Optimisation settings for the protection window
- **Include setting in `SETTINGS_TO_SYNC`** so it syncs across Macs via iCloud

## Root Cause

When `OptimisedFileBehaviour` is `sameFolder` (or `specificFolder`), `process()` copies the original to a new `-optimised` path and optimises the copy. The original file was never marked with an xattr, so when iCloud Drive's `bird` daemon syncs the new file and generates fresh FSEvents (`.itemModified`/`.itemRenamed`) on the original, it passes all checks again and gets re-optimised — creating duplicate `-optimised 2.png` files from iCloud conflict renames.

## Changed Files

| File | Change |
|------|--------|
| `Clop/ClopApp.swift` | Mark `oldPath` with xattr, use configurable TTL, add `newPath` cleanup |
| `Clop/Settings.swift` | Add `optimisedFileProtectionMs` key (default 3000ms) + add to `SETTINGS_TO_SYNC` |
| `Clop/SettingsView.swift` | Add protection window picker in General > Optimisation section |

## Test plan

- [ ] Build the project in Xcode
- [ ] Set image behaviour to "Same folder" with default template `%f-optimised`
- [ ] Save a screenshot to an iCloud-synced Desktop
- [ ] Verify exactly ONE `-optimised` file is created, no " 2" duplicates
- [ ] Wait 60s, verify no re-optimisation occurs
- [ ] Check xattr on original: `xattr -l <original>` should show `clop.optimisation.status`
- [ ] Verify the new picker appears in General > Optimisation settings
- [ ] Change protection window to 30s, verify setting persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)